### PR TITLE
Improve Routing

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Single Page Apps for GitHub Pages</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+
+      // If you're creating a Project Pages site and NOT using a custom domain,
+      // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+      // This way the code will only replace the route part of the path, and not
+      // the real directory in which the app resides, for example:
+      // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+      // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+      // Otherwise, leave pathSegmentsToKeep as 0.
+      var pathSegmentsToKeep = 0;
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -99,6 +99,32 @@
       href="https://fonts.googleapis.com/css?family=Rubik&display=swap"
       rel="stylesheet"
     />
+
+    <!-- Start Single Page Apps for GitHub Pages -->
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script checks to see if a redirect is present in the query string,
+      // converts it back into the correct url and adds it to the
+      // browser's history using window.history.replaceState(...),
+      // which won't cause the browser to attempt to load the new url.
+      // When the single page app is loaded further down in this file,
+      // the correct url will be waiting in the browser's history for
+      // the single page app to route accordingly.
+      (function(l) {
+        if (l.search[1] === '/' ) {
+          var decoded = l.search.slice(1).split('&').map(function(s) { 
+            return s.replace(/~and~/g, '&')
+          }).join('?');
+          window.history.replaceState(null, null,
+              l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      }(window.location))
+    </script>
+    <!-- End Single Page Apps for GitHub Pages -->
+
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Route, Switch, HashRouter } from "react-router-dom"
+import { Route, Switch } from "react-router-dom"
 import history from "./history"
 import "./App.scss"
 
@@ -10,19 +10,17 @@ import { Nav } from "app/components"
 function App() {
   return (
     <div className="App">
-      <HashRouter history={history} basename="/Zothacks-Site">
-        <Nav history={history}></Nav>
-        <Switch>
-          <Route exact path="/" component={Home} />
-          <Route exact path="/schedule" component={Schedule} />
-          <Route exact path="/starter-packs" component={StarterPacks} />
-        
-          <Route path='/github' component={() => { 
-            window.location.href = 'https://education.github.com/discount_requests/student_application?utm_source=2020-11-13-ZotHacks2020'; 
-            return null;
-          }}/>
-        </Switch>
-      </HashRouter>
+      <Nav history={history}></Nav>
+      <Switch>
+        <Route exact path="/" component={Home} />
+        <Route exact path="/schedule" component={Schedule} />
+        <Route exact path="/starter-packs" component={StarterPacks} />
+      
+        <Route path='/github' component={() => { 
+          window.location.href = 'https://education.github.com/discount_requests/student_application?utm_source=2020-11-13-ZotHacks2020'; 
+          return null;
+        }}/>
+      </Switch>
     </div>
   )
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import { BrowserRouter } from 'react-router-dom';
 
 ReactDOM.render(
     <BrowserRouter>
-        <App />, 
+        <App /> 
     </BrowserRouter>,
     document.getElementById('root')
 );

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,14 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
+import { BrowserRouter } from 'react-router-dom';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(
+    <BrowserRouter>
+        <App />, 
+    </BrowserRouter>,
+    document.getElementById('root')
+);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.


### PR DESCRIPTION
Our routes no longer need the # in them!

I found a way to exploit the 404 page, in order to enable proper routing for SPA React Sites on GitHub Pages.
Basically, we have a 404.html page that redirects to index.html, including the route as query params. Our index.html takes those query params, redirects to the correct page, and updates the browser history accordingly.

Full explanation can be found here: https://github.com/rafgraph/spa-github-pages#how-it-works

I've already deployed this routing branch to verify that everything works. Sorry for doing our review process a bit backwards but it didn't make sense to open this PR without testing that the change worked as intended.
(And it would've been a simple rollback to redeploy the previous master, had anything gone wrong)

Feel free to check it out for yourself :)
- https://zothacks.com/starter-packs
- https://zothacks.com/schedule