### PR TITLE
Enable semicolons in Prettier configuration

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,6 +1,6 @@
 // prettier.config.js or .prettierrc.js
 module.exports = {
   tabWidth: 2,
-  semi: false,
+  semi: true,
   singleQuote: false,
-}
+};


### PR DESCRIPTION
Enable semicolons to make code formatting consistent across our repositories